### PR TITLE
Fix debug actions issue on 1.6

### DIFF
--- a/Source/EliteBionicsFramework/Util/DebugActionsEBF.cs
+++ b/Source/EliteBionicsFramework/Util/DebugActionsEBF.cs
@@ -6,7 +6,7 @@ namespace EBF.Util
 {
     public static class DebugActionsEBF
     {
-        [DebugAction("Elite Bionics Framework", name = "Dump mod detection info")]
+        [DebugAction("Elite Bionics Framework", "Dump mod detection info")]
         public static void DumpModDetectionInfo()
         {
             StringBuilder builder = new StringBuilder("Elite Bionics Framework: mod detection info");


### PR DESCRIPTION
This fixes a nasty error if you try to open the debug actions on rimworld 1.6
